### PR TITLE
Inject MOTD (flag-controlled).

### DIFF
--- a/bridge-motd.txt
+++ b/bridge-motd.txt
@@ -1,0 +1,9 @@
+─────────────────────────────────────────────────────────────────
+You connected to a public RobustIRC bridge.
+
+BY NOT RUNNING A BRIDGE ON THE SAME MACHINE AS YOUR IRC CLIENT,
+YOU DONT GET TRANSPARENT HANDLING OF NETWORK CONNECTION FAILURES.
+
+Please run your own bridge instead. For instructions, see
+http://robustirc.net/
+─────────────────────────────────────────────────────────────────

--- a/robustirc-bridge/bridge.go
+++ b/robustirc-bridge/bridge.go
@@ -48,6 +48,13 @@ var (
 // - for resuming sessions (later): the last seen message id, perhaps setup messages (JOINs, MODEs, …)
 // for hosted mode, this state is stored per-nickname, ideally encrypted with password
 
+// prefixMotd takes an irc.MOTD message from the server and prefixes it with
+// our own MOTD. E.g., it takes:
+//   :robustirc.net 372 sECuRE :- First line of MOTD\r\n
+// and turns that into:
+//   :robustirc.net 372 sECuRE :- First line of bridge MOTD\r\n
+//   :robustirc.net 372 sECuRE :- Thanks for using this bridge! Enjoy!\r\n
+//   :robustirc.net 372 sECuRE :- First line of MOTD\r\n
 func prefixMotd(msg string) string {
 	// The user chose to not inject a MOTD.
 	if *motdPath == "" {

--- a/robustirc-bridge/bridge.go
+++ b/robustirc-bridge/bridge.go
@@ -195,6 +195,7 @@ func (p *bridge) handleIRC(conn net.Conn) {
 
 	keepalivePong := ":" + robustSession.IrcPrefix.String() + " PONG keepalive"
 	motdPrefix := ":" + robustSession.IrcPrefix.String() + " 372 "
+	motdInjected := false
 
 	keepaliveToNetwork := time.After(1 * time.Minute)
 	keepaliveToClient := time.After(1 * time.Minute)
@@ -222,7 +223,7 @@ func (p *bridge) handleIRC(conn net.Conn) {
 		select {
 		case msg := <-robustSession.Messages:
 			// Inject the bridge’s message of the day.
-			if strings.HasPrefix(msg, motdPrefix) {
+			if !motdInjected && strings.HasPrefix(msg, motdPrefix) {
 				sendIRC = []byte(prefixMotd(msg))
 				break
 			}


### PR DESCRIPTION
By default, we inject a MOTD stating that users should not use public
bridges.
