### PR TITLE
Fix build on Windows

### DIFF
--- a/robustirc-bridge/bridge.go
+++ b/robustirc-bridge/bridge.go
@@ -21,7 +21,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -470,19 +469,6 @@ func maybeTLSListener(addr string) net.Listener {
 	return tls.NewListener(tcpKeepAliveListener{ln.(*net.TCPListener)}, tlsconfig)
 }
 
-func nfds() int {
-	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
-	if err != nil || pid != os.Getpid() {
-		return 0
-	}
-
-	n, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
-	if err != nil {
-		return 0
-	}
-	return n
-}
-
 func main() {
 	flag.Parse()
 
@@ -579,40 +565,8 @@ func main() {
 			}()
 		}
 	} else if n := nfds(); *network != "" && n > 0 {
-		names := strings.Split(os.Getenv("LISTEN_FDNAMES"), ":")
-		os.Unsetenv("LISTEN_PID")
-		os.Unsetenv("LISTEN_FDS")
-		os.Unsetenv("LISTEN_FDNAMES")
-
-		p := newBridge(*network)
-
-		const listenFdsStart = 3 // SD_LISTEN_FDS_START
-		for fd := listenFdsStart; fd < listenFdsStart+n; fd++ {
-			syscall.CloseOnExec(fd)
-			name := "LISTEN_FD_" + strconv.Itoa(fd)
-			offset := fd - listenFdsStart
-			if offset < len(names) && len(names[offset]) > 0 {
-				name = names[offset]
-			}
-			log.Printf("RobustIRC IRC bridge listening on file descriptor %d (%s)", fd, name)
-			f := os.NewFile(uintptr(fd), name)
-			ln, err := net.FileListener(f)
-			if err != nil {
-				log.Fatal(err)
-			}
-			f.Close()
-			go func() {
-				for {
-					conn, err := ln.Accept()
-					if err != nil {
-						log.Printf("Could not accept IRC client connection: %v\n", err)
-						// Avoid flooding the logs with failed Accept()s.
-						time.Sleep(1 * time.Second)
-						continue
-					}
-					go p.handleIRC(conn)
-				}
-			}()
+		if err := handleSocketActivation(); err != nil {
+			log.Fatal(err)
 		}
 	}
 	select {} // sleep forever

--- a/robustirc-bridge/socket_activation.go
+++ b/robustirc-bridge/socket_activation.go
@@ -1,0 +1,70 @@
+// +build !windows
+
+package main
+
+import (
+	"log"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// nfds returns the number of listening file descriptors as passed by systemd
+// when this application is started using systemd socket activation.
+func nfds() int {
+	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
+	if err != nil || pid != os.Getpid() {
+		return 0
+	}
+
+	n, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// handleSocketActivation handles listening on the systemd-provided sockets.
+// It can return an error to differentiate between this implementation and
+// the no-op on Windows.
+func handleSocketActivation() error {
+	names := strings.Split(os.Getenv("LISTEN_FDNAMES"), ":")
+	os.Unsetenv("LISTEN_PID")
+	os.Unsetenv("LISTEN_FDS")
+	os.Unsetenv("LISTEN_FDNAMES")
+
+	p := newBridge(*network)
+
+	const listenFdsStart = 3 // SD_LISTEN_FDS_START
+	for fd := listenFdsStart; fd < listenFdsStart+n; fd++ {
+		syscall.CloseOnExec(fd)
+		name := "LISTEN_FD_" + strconv.Itoa(fd)
+		offset := fd - listenFdsStart
+		if offset < len(names) && len(names[offset]) > 0 {
+			name = names[offset]
+		}
+		log.Printf("RobustIRC IRC bridge listening on file descriptor %d (%s)", fd, name)
+		f := os.NewFile(uintptr(fd), name)
+		ln, err := net.FileListener(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		f.Close()
+		go func() {
+			for {
+				conn, err := ln.Accept()
+				if err != nil {
+					log.Printf("Could not accept IRC client connection: %v\n", err)
+					// Avoid flooding the logs with failed Accept()s.
+					time.Sleep(1 * time.Second)
+					continue
+				}
+				go p.handleIRC(conn)
+			}
+		}()
+	}
+	return nil
+}

--- a/robustirc-bridge/socket_activation_windows.go
+++ b/robustirc-bridge/socket_activation_windows.go
@@ -1,0 +1,16 @@
+// +build windows
+
+package main
+
+import "errors"
+
+// nfds returns 0 to indicate that systemd socket activation is unsupported on Windows.
+func nfds() int {
+	return 0
+}
+
+// handleSocketActivation is no-op on Windows. It returns an error to be able terminate the program
+// instead of sleeping indefinitely.
+func handleSocketActivation() error {
+	return errors.New("systemd socket activation is not available on Windows")
+}


### PR DESCRIPTION
Windows has a different signature for the syscall.CloseOnExec func and
based on quick research Windows's CloseOnExec might also behave
differently. [1]

I didn't put more effort into making this work because systemd socket
activation on Windows is a very unlikely scenario in any case.

[1] https://github.com/cloudflare/tableflip/issues/40