### PR TITLE
Add flag to ignore server list updates.

### DIFF
--- a/robustirc-bridge/bridge.go
+++ b/robustirc-bridge/bridge.go
@@ -79,6 +79,10 @@ var (
 	unavailableMessageFormat = flag.String("unavailable_message_format",
 		"%s",
 		"Format string for a message to inject when the RobustIRC network becomes unavailable")
+
+	ignoreServerListUpdates = flag.Bool("ignore_server_list_updates",
+		false,
+		"RobustPing messages contain the current list of server addresses of the network, which robustsession uses to keep the list of servers up to date without having to periodically re-resolve the DNS names (--network flag). If IgnoreServerListUpdates is true, robustsession will ignore the list of servers. This is useful when working with different names on client and server, for example when the client connects via a port forwarding.")
 )
 
 // TODO(secure): persistent state:
@@ -308,6 +312,7 @@ func (p *bridge) handleIRC(conn net.Conn) {
 	robustSession.BridgeAuth = p.auth
 	robustSession.ForwardedFor = conn.RemoteAddr().String()
 	robustSession.UnavailableMessageFormat = *unavailableMessageFormat
+	robustSession.IgnoreServerListUpdates = *ignoreServerListUpdates
 
 	log.Printf("[session %s] Created RobustSession for client %s\n", robustSession.SessionId(), conn.RemoteAddr())
 

--- a/robustsession/robustsession.go
+++ b/robustsession/robustsession.go
@@ -273,6 +273,14 @@ type RobustSession struct {
 	// Format string for unavailability messages to inject.
 	UnavailableMessageFormat string
 
+	// RobustPing messages contain the current list of server addresses of the network,
+	// which robustsession uses to keep the list of servers up to date
+	// without having to periodically re-resolve the DNS names (--network flag).
+	// If IgnoreServerListUpdates is true, robustsession will ignore the list of servers.
+	// This is useful when working with different names on client and server,
+	// for example when the client connects via a port forwarding.
+	IgnoreServerListUpdates bool
+
 	sessionAuth string
 	deleted     bool
 	done        chan bool
@@ -493,7 +501,7 @@ func (s *RobustSession) getMessages() {
 				break
 			}
 			if msg.Type == robustPing {
-				if len(msg.Servers) > 0 {
+				if len(msg.Servers) > 0 && !s.IgnoreServerListUpdates {
 					s.network.setServers(msg.Servers)
 				}
 			} else if msg.Type == robustIRCToClient {


### PR DESCRIPTION
This is useful when working with different names on client and server, for example when the client connects via a port forwarding.