### PR TITLE
Improvements to shutdown logic

### DIFF
--- a/robustirc-bridge/bridge.go
+++ b/robustirc-bridge/bridge.go
@@ -371,6 +371,15 @@ func (p *bridge) handleIRC(conn net.Conn) {
 			sendRobust = nil
 		}
 
+		// Ensure that we pump signalChan first if anything is waiting in it.
+		select {
+		case sig := <-signalChan:
+			killmsg = fmt.Sprintf("Bridge exiting upon receiving signal (%v)", sig)
+			quitmsg = killmsg
+			return
+		default:
+		}
+
 		select {
 		case sig := <-signalChan:
 			killmsg = fmt.Sprintf("Bridge exiting upon receiving signal (%v)", sig)

--- a/robustirc-bridge/socket_activation_windows.go
+++ b/robustirc-bridge/socket_activation_windows.go
@@ -3,7 +3,10 @@
 
 package main
 
-import "errors"
+import (
+	"errors"
+	"sync"
+)
 
 // nfds returns 0 to indicate that systemd socket activation is unsupported on Windows.
 func nfds() int {
@@ -12,6 +15,6 @@ func nfds() int {
 
 // handleSocketActivation is no-op on Windows. It returns an error to be able terminate the program
 // instead of sleeping indefinitely.
-func handleSocketActivation(n int) error {
+func handleSocketActivation(n int, connWG *sync.WaitGroup) error {
 	return errors.New("systemd socket activation is not available on Windows")
 }

--- a/robustirc-bridge/socks.go
+++ b/robustirc-bridge/socks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sync"
 	"time"
 )
 
@@ -54,7 +55,7 @@ type socksConnectionData struct {
 	Port     uint16
 }
 
-func serveSocks(ln net.Listener) error {
+func serveSocks(ln net.Listener, connWG *sync.WaitGroup) error {
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -63,7 +64,9 @@ func serveSocks(ln net.Listener) error {
 			time.Sleep(1 * time.Second)
 			continue
 		}
+		connWG.Add(1)
 		go func() {
+			defer connWG.Done()
 			s := &socksServer{conn}
 
 			if err := s.handleConn(); err != nil {


### PR DESCRIPTION
In summary:

* Add a new flag `--shutdown_timeout` for configuring the timeout after SIGTERM to give up waiting for all connections to close cleanly
* Keep track of the open connections, so we can stop waiting for them if they have all managed to quit
* Ensure the shutdown signal is handled ahead of the main handling loop to avoid it getting starved if we have lots of messages and we are unlucky in Go's select-randomisation